### PR TITLE
Flexport cop improvements

### DIFF
--- a/lib/rubocop/sorbet_from_contract_service.rb
+++ b/lib/rubocop/sorbet_from_contract_service.rb
@@ -27,7 +27,6 @@ module Sorbet
     def self.source(node, args, ret)
       arg_names = arg_names(node)
       arg_types = args.map { |arg| convert(arg) }.flatten
-      return nil unless arg_types.any? && arg_types.all?
       return_types = convert(ret)
       format_source(arg_types, arg_names, return_types)
     rescue AutoCorrectError => e
@@ -37,7 +36,11 @@ module Sorbet
 
     def self.format_source(arg_types, arg_names, return_types)
       if arg_names.empty?
-        format("sig { returns(%s) }", return_types)
+        if return_types.nil?
+          format("sig { void }", [])
+        else
+          format("sig { returns(%s) }", return_types)
+        end
       else
         params = arg_names.zip(arg_types).map do |arg, arg_type|
           arg_name = CONTRACT_ARGS_PATTERN.match(arg).to_s

--- a/lib/rubocop_sorbet.rb
+++ b/lib/rubocop_sorbet.rb
@@ -20,3 +20,5 @@ require_relative 'rubocop/cop/sorbet/sigils/true_sigil'
 require_relative 'rubocop/cop/sorbet/sigils/strict_sigil'
 require_relative 'rubocop/cop/sorbet/sigils/strong_sigil'
 require_relative 'rubocop/cop/sorbet/sigils/enforce_sigil_order'
+
+require_relative 'rubocop/cop/sorbet/prefer_sorbet_over_contracts'

--- a/spec/cop/sorbet/prefer_sorbet_over_contracts_spec.rb
+++ b/spec/cop/sorbet/prefer_sorbet_over_contracts_spec.rb
@@ -130,29 +130,60 @@ RSpec.describe(RuboCop::Cop::Sorbet::PreferSorbetOverContracts, :config) do
     end
 
     describe "Auto-corrects void" do
-      let(:source) do
-        <<~RUBY
-          class Example
-            Contract String => nil
-            def self.cool_thing(str)
-            end
+      context 'there is a param' do
+        context 'param is string' do
+          let(:source) do
+            <<~RUBY
+              class Example
+                Contract String => nil
+                def self.cool_thing(str)
+                end
+              end
+            RUBY
           end
-        RUBY
-      end
-      let(:fixed_source) do
-        <<~RUBY
-          class Example
-            extend T::Sig
-            sig { params(str: String).void }
-            def self.cool_thing(str)
-            end
+          let(:fixed_source) do
+            <<~RUBY
+              class Example
+                extend T::Sig
+                sig { params(str: String).void }
+                def self.cool_thing(str)
+                end
+              end
+            RUBY
           end
-        RUBY
+
+          it "autocorrects the offense" do
+            new_source = autocorrect_source(source)
+            expect(new_source).to(eq(fixed_source))
+          end
+        end
       end
 
-      it "autocorrects the offense" do
-        new_source = autocorrect_source(source)
-        expect(new_source).to(eq(fixed_source))
+      context 'there is no param' do
+        let(:source) do
+          <<~RUBY
+            class Example
+              Contract None => nil
+              def self.cool_thing
+              end
+            end
+          RUBY
+        end
+        let(:fixed_source) do
+          <<~RUBY
+            class Example
+              extend T::Sig
+              sig { void }
+              def self.cool_thing
+              end
+            end
+          RUBY
+        end
+
+        it "autocorrects the offense" do
+          new_source = autocorrect_source(source)
+          expect(new_source).to(eq(fixed_source))
+        end
       end
     end
 
@@ -821,6 +852,125 @@ RSpec.describe(RuboCop::Cop::Sorbet::PreferSorbetOverContracts, :config) do
 
         it "autocorrects the offense" do
           new_source = autocorrect_source(src)
+          expect(new_source).to(eq(fixed_source))
+        end
+      end
+    end
+
+    describe "Autocorrect works for shorthand no param list" do
+      context 'return param is a boolean' do
+        let(:source) do
+          <<~RUBY
+            class ClassWithShorthandNoParams
+              Contract Bool
+              def returns_bool
+                return false
+              end
+            end
+          RUBY
+        end
+        let(:fixed_source) do
+          <<~RUBY
+            class ClassWithShorthandNoParams
+              extend T::Sig
+              sig { returns(T::Boolean) }
+              def returns_bool
+                return false
+              end
+            end
+          RUBY
+        end
+
+        it "autocorrects the offense" do
+          new_source = autocorrect_source(source)
+          expect(new_source).to(eq(fixed_source))
+        end
+
+      end
+
+      context 'return param is a hash' do
+        let(:source) do
+          <<~RUBY
+            class ClassWithShorthandNoParams
+              Contract HashOf[Symbol => Symbol]
+              def returns_bool
+                return false
+              end
+            end
+          RUBY
+        end
+        let(:fixed_source) do
+          <<~RUBY
+            class ClassWithShorthandNoParams
+              extend T::Sig
+              sig { returns(T::Hash[Symbol, Symbol]) }
+              def returns_bool
+                return false
+              end
+            end
+          RUBY
+        end
+
+        it "autocorrects the offense" do
+          new_source = autocorrect_source(source)
+          expect(new_source).to(eq(fixed_source))
+        end
+      end
+
+      context 'return param is nil' do
+        let(:source) do
+          <<~RUBY
+            class ClassWithShorthandNoParams
+              Contract nil
+              def returns_bool
+                return false
+              end
+            end
+          RUBY
+        end
+        let(:fixed_source) do
+          <<~RUBY
+            class ClassWithShorthandNoParams
+              extend T::Sig
+              sig { void }
+              def returns_bool
+                return false
+              end
+            end
+          RUBY
+        end
+
+        it "autocorrects the offense" do
+          new_source = autocorrect_source(source)
+          expect(new_source).to(eq(fixed_source))
+        end
+      end
+
+      context 'return param is any' do
+        let(:source) do
+          <<~RUBY
+            class ClassWithShorthandNoParams
+              Contract Any
+              def returns_bool
+                return false
+              end
+            end
+          RUBY
+        end
+        let(:fixed_source) do
+          <<~RUBY
+            class ClassWithShorthandNoParams
+              extend T::Sig
+              sig { returns(T.untyped) }
+              def returns_bool
+                return false
+              end
+            end
+          RUBY
+        end
+
+        it "autocorrects the offense" do
+          new_source = autocorrect_source(source)
           expect(new_source).to(eq(fixed_source))
         end
       end


### PR DESCRIPTION
This makes several fixes to the flexport contracts codemod.
1) Allows shorthand contracts like `Contract Bool` to be converted
2) Fixes an issue where we create malformed sigs if a contract has no return type

It is recommended to read this with "hide whitespace change" checked.